### PR TITLE
Add regression tests for pending submission date handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.pyo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_pending_submission_dt.py
+++ b/tests/test_pending_submission_dt.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from bot.config import CFG
+from bot.main import _pending_submission_dt
+
+
+def _dt(year, month, day, hour=0, minute=0, second=0):
+    return datetime(year, month, day, hour, minute, second, tzinfo=CFG.tz_moscow)
+
+
+def test_pending_submission_dt_prefers_iso():
+    original = _dt(2025, 10, 6, 23, 50)
+    result = _pending_submission_dt({"dt_iso": original.isoformat()})
+    assert result == original
+
+
+def test_pending_submission_dt_falls_back_to_day_key():
+    original = _dt(2025, 10, 6, 8, 30)
+    result = _pending_submission_dt({"day": original.strftime("%Y-%m-%d")})
+    assert result.date() == original.date()
+    assert result.tzinfo == CFG.tz_moscow


### PR DESCRIPTION
## Summary
- add regression tests covering `_pending_submission_dt`'s ISO and day-key parsing
- configure pytest path handling and ignore Python bytecode caches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e464af92f4832387f5885bf6c3fc32