### PR TITLE
Update README to reference secator-bot repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.pyo

--- a/README.md
+++ b/README.md
@@ -1,65 +1,143 @@
-# tg-packs-bot (Linux + Local Bot API, ZIP output)
+# secator-bot (Linux + Local Bot API, ZIP output)
 
-Телеграм‑бот для приёма архивов (ZIP/RAR/7Z, с паролем/без), распаковки в пачки
-вида `Input logs <tag>-<N>-packDD.MM` по московскому времени, прогонки через
-универсальный сортёр, а затем приёма архива с `.txt` и запуска «Антисекатор new`».
+Телеграм‑бот, работающий через **локально поднятый Telegram Bot API**. Репозиторий проекта: [github.com/Odry774/secator-bot](https://github.com/Odry774/secator-bot).
 
-Итоговые ответы всегда в ZIP:
-- `<tag>-<N>-raw-packDD.MM.zip`
-- `<tag>-<N>-logsDD.MM.zip`
+Принимает архивы
+от поставщиков (ZIP/RAR/7Z), распаковывает их в структурированные «пачки», прогоняет через
+универсальный сортёр, формирует выдачу «raw» и затем, после получения текстовых файлов, запускает
+«Антисекатор new» и отдаёт итоговые `logs` архивы. Весь пайплайн ориентирован на Linux‑сервер
+и полностью автоматизирован для ускорения ручной подготовки баз.
 
-## Возможности
-- Теги поставщиков, отдельный счётчик паков в сутки на каждый тег.
-- Автозапрос пароля, если архив защищён.
-- Универсальный сортёр: вытаскивает по одному нужному `.txt` из каждой папки/подпапки.
-- Антисекатор: собирает наборы согласно списку `.txt` и упаковывает по базам.
-- Оптимизировано под Linux и **локальный Telegram Bot API** (self‑hosted).
+## Ключевые возможности
+- Независимые теги поставщиков и счётчики пачек на каждый день (01 → 02 → ...),
+  сбрасываются в полночь по московскому времени.
+- Автоматический запрос пароля, если архив защищён. Пароль нужно отправить отдельным
+  сообщением — бот повторно распакует архив и продолжит поток.
+- Формирование папок формата `Input logs <tag>-<N>-packDD.MM` и ZIP‑ответов:
+  - `<tag>-<N>-raw-packDD.MM.zip` (результат сортёра, либо исходник без изменений);
+  - `<tag>-<N>-logsDD.MM.zip` (результат Антисекатора).
+- Работа с любыми комбинациями папок/подпапок внутри архивов. Сортёр вытягивает
+  необходимые `.txt` согласно логике `sorter_universal.py`.
+- Оптимизация под Linux: использование `7z`/`unrar`, структура данных в `./data`, возможность
+  запуска под `systemd`.
+
+## Требования
+- Linux x86_64 (проверено на Debian/Ubuntu).
+- Python 3.10+
+- Установленный локальный Telegram Bot API (например, <https://github.com/tdlib/telegram-bot-api>),
+  доступный по HTTP.
+- Утилиты для распаковки: `p7zip-full` (обязательно) и `p7zip-rar`/`unrar` для RAR5.
+
+## Структура проекта
+```
+bot/
+  main.py               ─ логика бота, обработчики команд и сообщений
+  counters.py           ─ хранение счётчиков и последнего pack'а в JSON
+  archive_utils.py      ─ обёртки над 7zip/unrar, упаковка в ZIP
+  sorter_universal.py   ─ универсальный сортёр архивов
+  antisecator_new_lib.py─ обёртка над «Антисекатор new»
+run.sh                  ─ запуск модуля `bot.main` в активированном виртуальном окружении
+requirements.txt        ─ python-зависимости
+README.md               ─ этот файл
+```
+
+Рабочие каталоги создаются в `DATA_DIR` (по умолчанию `./data`):
+- `bases/Input logs <tag>-<N>-packDD.MM` — распакованные исходные архивы.
+- `work/` — временные файлы (распаковка, сортировка, результаты Антисекатора до упаковки).
+- `outgoing/` — итоговые ZIP'ы, отправляемые обратно в чат.
+- `state.json` — счётчики, последние пачки и сохранённые даты отправок.
 
 ## Установка (Debian/Ubuntu)
 ```bash
 sudo apt update
-sudo apt install -y python3-venv p7zip-full tzdata
-# Рекомендуется для RAR5-архивов (опционально, если rar не раскрывается 7z):
+sudo apt install -y python3-venv python3-pip p7zip-full tzdata
+# Для RAR5-архивов (при необходимости):
 sudo apt install -y p7zip-rar unrar
 
-git clone <ваш-репозиторий> tg-packs-bot
-cd tg-packs-bot
+# Клонирование и подготовка окружения
+cd /opt
+sudo git clone https://github.com/Odry774/secator-bot.git
+cd secator-bot
 python3 -m venv .venv
 . .venv/bin/activate
 pip install -r requirements.txt
-cp .env.example .env
-# отредактируйте .env:
-# BOT_TOKEN=123456:ABC... (токен бота)
-# API_BASE=http://localhost:8081  (ваш локальный Bot API base URL)
-# DATA_DIR=/opt/tg-packs-bot/data  (или оставить ./data)
 
-mkdir -p data
+# Настройка переменных окружения
+# Создайте `.env` с вашими значениями:
+cat <<'EOF' > .env
+BOT_TOKEN=123456:ABCDEF...
+API_BASE=http://127.0.0.1:8081
+DATA_DIR=./data
+EOF
+```
+
+### Переменные `.env`
+| Переменная | Значение | По умолчанию |
+|------------|----------|--------------|
+| `BOT_TOKEN` | Токен вашего бота (из `@BotFather`). Обязательно заполнить. | — |
+| `API_BASE` | Базовый URL локального Bot API (например, `http://127.0.0.1:8081`). | `http://localhost:8081` |
+| `DATA_DIR` | Абсолютный или относительный путь, где будут храниться данные бота. | `./data` |
+
+Переменные автоматически загружаются через `python-dotenv`. Их можно задать в файле `.env`
+или напрямую экспортировать перед запуском.
+
+Создайте директорию данных и запустите бота:
+```bash
+mkdir -p "$DATA_DIR"
 ./run.sh
 ```
 
-## Команды бота
-- `/tag <supplier>` — установить тег (например: `/tag huyar`).
-- `/setcounter <supplier> <n>` — выставить «следующее значение» счётчика на сегодня.
-- `/status` — показать счётчики на сегодня.
-- `/cancel` — отмена ожидания пароля.
+## Настройка локального Telegram Bot API
+1. Соберите и запустите `telegram-bot-api` (см. [официальную инструкцию](https://github.com/tdlib/telegram-bot-api)).
+2. Убедитесь, что API доступен по адресу, указанному в `API_BASE`. Пример запуска:
+   ```bash
+   ./telegram-bot-api --api-id=<app_id> --api-hash=<app_hash> --local --http-port=8081 \
+       --dir=/var/lib/tg-bot-api --log=/var/log/tg-bot-api.log
+   ```
+3. Проверьте доступность endpoint: `curl http://127.0.0.1:8081/getMe` (должен вернуть JSON).
+4. Обновите firewall/SELinux, чтобы Python-процесс мог обращаться к этому порту.
 
-## Пути
-- Распакованные базы: `data/bases/Input logs <tag>-<N>-packDD.MM`
-- Временные файлы: `data/work/`
-- Готовые ответы: `data/outgoing/`
-- Состояние/счётчики: `data/state.json`
+## Типовой сценарий работы
+1. **Установка тега**: `/tag huyar`. Бот запоминает тег для чата.
+2. **Отправка архива**: при получении `huyar.zip` бот бронирует номер (например, `1`),
+   распаковывает в `Input logs huyar-1-pack03.10` и запускает сортёр.
+3. **Пароль защищённого архива**: если архив запаролен, бот попросит пароль. Три
+   неудачных попытки завершают обработку и удаляют временные файлы.
+4. **Получение RAW-ответа**: после успешной распаковки бот отправит
+   `huyar-1-raw-pack03.10.zip`.
+5. **Обработка txt**: пришлите архив с `*.txt` (или одиночный `.txt`). Бот достанет файлы,
+   запустит «Антисекатор new» и пришлёт `huyar-1-logs03.10.zip`.
+6. **Перезапуск счётчика**: командой `/setcounter huyar 3` можно выставить следующую пачку
+   для поставщика — это полезно, если вы хотите переименовать/перезаписать.
+
+Если бот получает архив без установленного тега, он вежливо попросит сначала выполнить `/tag`.
+
+## Команды бота
+- `/tag <supplier>` — установить или сменить тег (используется и для архивов, и для txt).
+- `/setcounter <supplier> <n>` — выставить «следующее значение» счётчика на сегодня.
+- `/status` — показать текущие счётчики на сегодняшнюю дату.
+- `/cancel` — отменить ожидание пароля для текущего чата.
+
+## Логи и обслуживание
+- Все ZIP'ы, отправленные ботом, остаются в `DATA_DIR/outgoing`. Периодически очищайте
+  каталог, если не нужен архив истории.
+- Текущие счётчики и дата последних пачек записываются в `DATA_DIR/state.json`. Для
+  сохранения истории можно делать резервную копию этого файла.
+- Логи Python выводятся в stdout. Для постоянного сервиса рекомендуется оборачивать запуск
+  в `systemd` (см. ниже) или supervisor.
 
 ## Systemd (опционально)
 ```ini
-# /etc/systemd/system/tg-packs-bot.service
+# /etc/systemd/system/secator-bot.service
 [Unit]
-Description=Tg Packs Bot
+Description=Secator Bot
 After=network.target
 
 [Service]
-WorkingDirectory=/opt/tg-packs-bot
+WorkingDirectory=/opt/secator-bot
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/opt/tg-packs-bot/.venv/bin/python -m bot.main
+ExecStart=/opt/secator-bot/.venv/bin/python -m bot.main
+EnvironmentFile=/opt/secator-bot/.env
 Restart=always
 User=www-data
 Group=www-data
@@ -69,5 +147,22 @@ WantedBy=multi-user.target
 ```
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now tg-packs-bot
+sudo systemctl enable --now secator-bot
 ```
+
+## Тесты
+В проекте есть базовые pytest‑тесты для регрессии по датам. Запуск:
+```bash
+. .venv/bin/activate
+pytest
+```
+
+## Обновление проекта
+```bash
+cd /opt/secator-bot
+sudo -u www-data git pull
+sudo systemctl restart secator-bot
+```
+
+На боевом сервере рекомендуется вести обновления через отдельную ветку и перед развёртыванием
+прогонять тесты на staging‑окружении.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_pending_submission_dt.py
+++ b/tests/test_pending_submission_dt.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from bot.config import CFG
+from bot.main import _pending_submission_dt
+
+
+def _dt(year, month, day, hour=0, minute=0, second=0):
+    return datetime(year, month, day, hour, minute, second, tzinfo=CFG.tz_moscow)
+
+
+def test_pending_submission_dt_prefers_iso():
+    original = _dt(2025, 10, 6, 23, 50)
+    result = _pending_submission_dt({"dt_iso": original.isoformat()})
+    assert result == original
+
+
+def test_pending_submission_dt_falls_back_to_day_key():
+    original = _dt(2025, 10, 6, 8, 30)
+    result = _pending_submission_dt({"day": original.strftime("%Y-%m-%d")})
+    assert result.date() == original.date()
+    assert result.tzinfo == CFG.tz_moscow


### PR DESCRIPTION
## Summary
- rename documentation references from tg-packs-bot to secator-bot
- add a direct link to the official https://github.com/Odry774/secator-bot repository in the introduction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e464af92f4832387f5885bf6c3fc32