### PR TITLE
Support local Bot API server downloads

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,7 +1,25 @@
 import os
 from dataclasses import dataclass
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 from zoneinfo import ZoneInfo
+
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _parse_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+
+    lowered = value.strip().lower()
+    if lowered in _TRUTHY:
+        return True
+    if lowered in _FALSY:
+        return False
+    return None
 
 load_dotenv()
 
@@ -11,5 +29,23 @@ class Config:
     api_base: str = os.environ.get("API_BASE", "http://localhost:8081")
     data_dir: str = os.environ.get("DATA_DIR", "./data")
     tz_moscow: ZoneInfo = ZoneInfo("Europe/Moscow")
+
+    @property
+    def api_is_local(self) -> bool:
+        override = _parse_bool(os.environ.get("API_LOCAL"))
+        if override is not None:
+            return override
+
+        host = urlparse(self.api_base).hostname
+        if not host:
+            return False
+
+        if host == "localhost" or host == "::1":
+            return True
+
+        if host.startswith("127."):
+            return True
+
+        return False
 
 CFG = Config()

--- a/bot/main.py
+++ b/bot/main.py
@@ -205,6 +205,9 @@ async def on_password(m: Message):
 async def on_txt_pack(m: Message):
     """Принимаем архив с .txt. Берём последний pack-info для чата (tag, n, day),
     запускаем Антисекатор по всем 'Input logs*' в BASES_DIR."""
+    if not m.document:
+        return
+
     last = get_last_pack_info(m.chat.id)
     tag = _get_tag_from_message(m) or (last and last["tag"])
     if not tag:
@@ -291,7 +294,11 @@ async def on_txt_password(m: Message):
     PENDING.pop(m.chat.id, None)
 
 async def main():
-    session = AiohttpSession(api=TelegramAPIServer.from_base(CFG.api_base))
+    api_server = TelegramAPIServer.from_base(
+        CFG.api_base,
+        is_local=CFG.api_is_local,
+    )
+    session = AiohttpSession(api=api_server)
     bot = Bot(CFG.bot_token, session=session)
     await dp.start_polling(bot, allowed_updates=dp.resolve_used_update_types())
 


### PR DESCRIPTION
## Summary
- detect when the configured Bot API server is local and enable local file access
- allow overriding the detection with the API_LOCAL environment variable

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68e465a499308323a6666c0d3939adb2